### PR TITLE
Add additional models and CRUD endpoints

### DIFF
--- a/app/database_models.py
+++ b/app/database_models.py
@@ -1,5 +1,5 @@
 from sqlmodel import SQLModel, Field, create_engine, Session
-from typing import Optional, List
+from typing import Optional, List, Dict
 from sqlalchemy import Column
 from sqlalchemy.dialects.sqlite import JSON
 import datetime
@@ -10,6 +10,42 @@ class Host(SQLModel):
     name: str
     type: str
     portainer_endpoint_id: int
+
+class User(SQLModel, table=True):
+    id: str = Field(primary_key=True)
+    username: str
+    email: str
+    password_hash: str
+    is_admin: bool = False
+    created_at: datetime.datetime = Field(default_factory=datetime.datetime.utcnow)
+
+class App(SQLModel, table=True):
+    id: str = Field(primary_key=True)
+    name: str
+    description: str
+    owner_id: str
+    compose_templates: Dict[str, str] = Field(default_factory=dict, sa_column=Column(JSON))
+    default_env: Optional[Dict[str, str]] = Field(default=None, sa_column=Column(JSON))
+
+class HostEntry(SQLModel, table=True):
+    id: str = Field(primary_key=True)
+    name: str
+    type: str
+    robot_id: str
+    portainer_endpoint_id: int
+    stack_id: Optional[int] = None
+    status: Optional[str] = None
+
+class Deployment(SQLModel, table=True):
+    id: str = Field(primary_key=True)
+    app_id: str
+    robot_id: str
+    owner_id: str
+    notes: Optional[str] = None
+    image_tags: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    env_overrides: Optional[Dict[str, Dict[str, str]]] = Field(default=None, sa_column=Column(JSON))
+    created_at: datetime.datetime = Field(default_factory=datetime.datetime.utcnow)
+    status: str
 
 class Robot(SQLModel, table=True):
     id: str = Field(primary_key=True)

--- a/app/main.py
+++ b/app/main.py
@@ -2,8 +2,11 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routers import robots, fleet, introspect, portainer
+from app.routers import apps, hosts, deployments, auth
+from app.database_models import create_db_and_tables
 
 app = FastAPI()
+create_db_and_tables()
 
 app.add_middleware(
     CORSMiddleware,
@@ -17,6 +20,10 @@ app.include_router(robots.router, prefix="/api/v1/robots")
 app.include_router(fleet.router, prefix="/api/v1/fleet")
 app.include_router(portainer.router, prefix="/api/v1/portainer")
 app.include_router(introspect.router, prefix="/api/v1/introspect")
+app.include_router(apps.router, prefix="/api/v1/apps")
+app.include_router(hosts.router, prefix="/api/v1/hosts")
+app.include_router(deployments.router, prefix="/api/v1/deployments")
+app.include_router(auth.router, prefix="/api/v1/auth")
 
 @app.get("/api/v1/health")
 def health_check():

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,12 @@
+from importlib import import_module
+
+robots = import_module('.robots', __name__)
+fleet = import_module('.fleet', __name__)
+portainer = import_module('.portainer', __name__)
+introspect = import_module('.introspect', __name__)
+apps = import_module('.apps', __name__)
+hosts = import_module('.hosts', __name__)
+deployments = import_module('.deployments', __name__)
+auth = import_module('.auth', __name__)
+
+__all__ = ['robots', 'fleet', 'portainer', 'introspect', 'apps', 'hosts', 'deployments', 'auth']

--- a/app/routers/apps.py
+++ b/app/routers/apps.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, HTTPException
+from sqlmodel import select
+from typing import List
+
+from app.database_models import App, get_session
+
+router = APIRouter()
+
+@router.get("/", response_model=List[App])
+def list_apps():
+    with get_session() as session:
+        apps = session.exec(select(App)).all()
+        return apps
+
+@router.post("/", response_model=App, status_code=201)
+def create_app(app: App):
+    with get_session() as session:
+        existing = session.get(App, app.id)
+        if existing:
+            raise HTTPException(status_code=409, detail="App already exists")
+        session.add(app)
+        session.commit()
+        session.refresh(app)
+        return app
+
+@router.get("/{app_id}", response_model=App)
+def get_app(app_id: str):
+    with get_session() as session:
+        app_obj = session.get(App, app_id)
+        if not app_obj:
+            raise HTTPException(status_code=404, detail="App not found")
+        return app_obj
+
+@router.put("/{app_id}", response_model=App)
+def update_app(app_id: str, updated: App):
+    with get_session() as session:
+        app_obj = session.get(App, app_id)
+        if not app_obj:
+            raise HTTPException(status_code=404, detail="App not found")
+        updated.id = app_id
+        session.merge(updated)
+        session.commit()
+        return updated
+
+@router.delete("/{app_id}", status_code=204)
+def delete_app(app_id: str):
+    with get_session() as session:
+        app_obj = session.get(App, app_id)
+        if not app_obj:
+            raise HTTPException(status_code=404, detail="App not found")
+        session.delete(app_obj)
+        session.commit()
+        return

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
+from sqlmodel import select
+from passlib.hash import bcrypt
+import jwt
+import datetime
+
+from app.database_models import User, get_session
+
+SECRET_KEY = "secret"
+
+router = APIRouter()
+
+class UserCreate(BaseModel):
+    username: str
+    email: str
+    password: str
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+@router.post("/register", response_model=User)
+def register(user: UserCreate):
+    with get_session() as session:
+        exists = session.exec(select(User).where(User.username == user.username)).first()
+        if exists:
+            raise HTTPException(status_code=409, detail="User exists")
+        new_user = User(
+            id=str(datetime.datetime.utcnow().timestamp()),
+            username=user.username,
+            email=user.email,
+            password_hash=bcrypt.hash(user.password),
+            is_admin=False,
+        )
+        session.add(new_user)
+        session.commit()
+        session.refresh(new_user)
+        return new_user
+
+@router.post("/login")
+def login(data: LoginRequest):
+    with get_session() as session:
+        user = session.exec(select(User).where(User.username == data.username)).first()
+        if not user or not bcrypt.verify(data.password, user.password_hash):
+            raise HTTPException(status_code=401, detail="Invalid credentials")
+        payload = {
+            "sub": user.id,
+            "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1),
+        }
+        token = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+        return {"access_token": token}

--- a/app/routers/deployments.py
+++ b/app/routers/deployments.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, HTTPException
+from sqlmodel import select
+from typing import List
+
+from app.database_models import Deployment, get_session
+
+router = APIRouter()
+
+@router.get("/", response_model=List[Deployment])
+def list_deployments():
+    with get_session() as session:
+        deps = session.exec(select(Deployment)).all()
+        return deps
+
+@router.post("/", response_model=Deployment, status_code=201)
+def create_deployment(dep: Deployment):
+    with get_session() as session:
+        existing = session.get(Deployment, dep.id)
+        if existing:
+            raise HTTPException(status_code=409, detail="Deployment already exists")
+        session.add(dep)
+        session.commit()
+        session.refresh(dep)
+        return dep
+
+@router.get("/{dep_id}", response_model=Deployment)
+def get_deployment(dep_id: str):
+    with get_session() as session:
+        dep = session.get(Deployment, dep_id)
+        if not dep:
+            raise HTTPException(status_code=404, detail="Deployment not found")
+        return dep
+
+@router.delete("/{dep_id}", status_code=204)
+def delete_deployment(dep_id: str):
+    with get_session() as session:
+        dep = session.get(Deployment, dep_id)
+        if not dep:
+            raise HTTPException(status_code=404, detail="Deployment not found")
+        session.delete(dep)
+        session.commit()
+        return

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, HTTPException
+from sqlmodel import select
+from typing import List
+
+from app.database_models import HostEntry, get_session
+
+router = APIRouter()
+
+@router.get("/", response_model=List[HostEntry])
+def list_hosts():
+    with get_session() as session:
+        hosts = session.exec(select(HostEntry)).all()
+        return hosts
+
+@router.post("/", response_model=HostEntry, status_code=201)
+def create_host(host: HostEntry):
+    with get_session() as session:
+        existing = session.get(HostEntry, host.id)
+        if existing:
+            raise HTTPException(status_code=409, detail="Host already exists")
+        session.add(host)
+        session.commit()
+        session.refresh(host)
+        return host
+
+@router.get("/{host_id}", response_model=HostEntry)
+def get_host(host_id: str):
+    with get_session() as session:
+        host = session.get(HostEntry, host_id)
+        if not host:
+            raise HTTPException(status_code=404, detail="Host not found")
+        return host
+
+@router.put("/{host_id}", response_model=HostEntry)
+def update_host(host_id: str, updated: HostEntry):
+    with get_session() as session:
+        host = session.get(HostEntry, host_id)
+        if not host:
+            raise HTTPException(status_code=404, detail="Host not found")
+        updated.id = host_id
+        session.merge(updated)
+        session.commit()
+        return updated
+
+@router.delete("/{host_id}", status_code=204)
+def delete_host(host_id: str):
+    with get_session() as session:
+        host = session.get(HostEntry, host_id)
+        if not host:
+            raise HTTPException(status_code=404, detail="Host not found")
+        session.delete(host)
+        session.commit()
+        return

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]==0.29.0
 sqlmodel==0.0.16
 httpx==0.27.0
 python-dotenv==1.0.1
+pyjwt==2.10.1
+passlib[bcrypt]==1.7.4


### PR DESCRIPTION
## Summary
- add SQLModel tables for user, apps, hosts, and deployments
- implement CRUD routers for apps, hosts, deployments, and auth
- expose new routers from the API and ensure DB tables are created
- include new dependencies for JWT auth

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python seed_mock_robot.py`

------
https://chatgpt.com/codex/tasks/task_e_684fe4d0ff3483268220216d46fecf0e